### PR TITLE
Change to Base Docker file to point to AIT-WATCHMAN instead of Watchm…

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -191,7 +191,7 @@ WORKDIR /src/rat-pac/tools/bonsai
 #	Should read: alias watch='python /src/watchmakers/watchmakers.py'
 
 WORKDIR /src
-RUN git clone https://github.com/MarcFBergevin/watchmakers.git
+RUN git clone https://github.com/AIT-WATCHMAN/watchmakers.git
 WORKDIR /src/watchmakers
 RUN ./configure
 #


### PR DESCRIPTION
…akers.

I will try to change the base manually and commit the change to the base tag. I assume this is only useful for the first install?